### PR TITLE
Update fish config and Ghostty theme/font settings

### DIFF
--- a/fish/config/config.fish
+++ b/fish/config/config.fish
@@ -34,10 +34,6 @@ if test -d /usr/local/sbin
     fish_add_path "/usr/local/sbin"
 end
 
-# Volta
-set -gx VOLTA_HOME "$HOME/.volta"
-set -gx PATH "$VOLTA_HOME/bin" $PATH
-
 # JetBrains
 fish_add_path "$HOME/Library/Application Support/JetBrains/Toolbox/scripts"
 
@@ -55,6 +51,7 @@ set -x JAVA_HOME /Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home
 
 # React
 set -gx REACT_EDITOR cursor
+set -gx EXPO_EDITOR "cursor"
 
 # bun
 set --export BUN_INSTALL "$HOME/.bun"

--- a/ghostty/config
+++ b/ghostty/config
@@ -1,12 +1,13 @@
 # theme = light:Monokai Pro Light,dark:Monokai Pro Ristretto
-theme = Monokai Pro Light
+# theme = Catppuccin Mocha
+theme = Catppuccin Latte
 
 adjust-cell-height = 10
 cursor-style = bar
 
 # Font settings
 font-family = Berkeley Mono Variable
-font-size = 16
+font-size = 18
 # Font slant (0 to -16)
 #   0 = Regular
 # -16 = Oblique


### PR DESCRIPTION
## Summary
- Remove Volta path setup from fish config (no longer needed)
- Add `EXPO_EDITOR` env var pointing to Cursor
- Switch Ghostty theme from Monokai Pro Light to Catppuccin Latte
- Bump Ghostty font size from 16 to 18

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only local shell and terminal configuration tweaks; no application logic or data paths affected.
> 
> **Overview**
> Updates local dev environment configs: removes Volta PATH setup from `fish/config/config.fish`, and adds `EXPO_EDITOR` set to Cursor alongside `REACT_EDITOR`.
> 
> Adjusts `ghostty/config` to use the Catppuccin Latte theme (with an updated commented alternative) and increases the terminal font size from 16 to 18.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71c7dd1171974ff5f1aa9878654d1ccf98450a59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->