### PR TITLE
Clean up fish config, aliases, and Brewfile

### DIFF
--- a/brew/Brewfile
+++ b/brew/Brewfile
@@ -41,6 +41,8 @@ brew "uv"
 brew "watchman"
 brew "wget"
 brew "z"
+brew "eza"
+brew "bat"
 brew "xcbeautify"
 brew "xcode-build-server"
 

--- a/fish/config/aliases.fish
+++ b/fish/config/aliases.fish
@@ -12,12 +12,9 @@ alias cp='cp -v'
 
 alias chmox='chmod -x'
 
-alias cask='brew cask'
 alias where=which
 
 alias hosts='sudo $EDITOR /etc/hosts'
-
-alias ag='ag -f --hidden'
 
 # ls with eza (modern replacement for ls)
 if type -q eza
@@ -40,7 +37,6 @@ end
 
 # Git aliases
 alias push="git push"
-alias undopush="git push -f origin HEAD^:master"
 alias master="git checkout master"
 
 # git root - cd to root of git repo
@@ -73,7 +69,6 @@ end
 
 # Networking
 alias ip="dig +short myip.opendns.com @resolver1.opendns.com"
-alias wget="curl -O"
 
 # Cleanup
 alias cleanup_dsstore="find . -name '*.DS_Store' -type f -ls -delete"

--- a/fish/config/config.fish
+++ b/fish/config/config.fish
@@ -34,9 +34,6 @@ if test -d /usr/local/sbin
     fish_add_path "/usr/local/sbin"
 end
 
-# JetBrains
-fish_add_path "$HOME/Library/Application Support/JetBrains/Toolbox/scripts"
-
 # Local bin
 fish_add_path "$HOME/.local/bin"
 
@@ -54,7 +51,10 @@ set -gx REACT_EDITOR cursor
 set -gx EXPO_EDITOR "cursor"
 
 # bun
-set --export BUN_INSTALL "$HOME/.bun"
-set --export PATH $BUN_INSTALL/bin $PATH
+set -gx BUN_INSTALL "$HOME/.bun"
+fish_add_path "$BUN_INSTALL/bin"
+
+# mise
+mise activate fish | source
 
 direnv hook fish | source

--- a/fish/config/fish_plugins
+++ b/fish/config/fish_plugins
@@ -1,3 +1,2 @@
 jorgebucaran/fisher
 jethrokuan/z
-rstacruz/fish-npm-global


### PR DESCRIPTION
## Summary
- Remove stale aliases: `brew cask` (removed from brew), `wget` (shadows real wget), `undopush` (force push to master), `ag` (not installed)
- Add `eza` and `bat` to Brewfile (referenced in aliases)
- Remove `fish-npm-global` plugin, keep only `fisher` and `z`
- Remove JetBrains Toolbox path from fish config
- Fix bun path setup to use `fish_add_path` instead of manual `PATH` manipulation
- Add `mise activate fish | source` to fish config