### PR TITLE
Add gh and mise configs, clean up starship and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,23 @@
 all: link run
-.PHONY: all
+.PHONY: all link run delete
 
 SHELL := /bin/bash
 
+# Symlink pattern (git configs)
 LINK = $(patsubst %.symlink, ~/%, $(notdir $(wildcard **/*.symlink) $(wildcard **/.*.symlink)))
-RUN  = $(wildcard **/*.install)
+
+# Install scripts
+RUN = $(wildcard **/*.install)
 
 ~/%: **/%.symlink
 	@echo "- Linking $<"
 	@ln -sF "$(CURDIR)/$<" "$@"
 
-delete:
-	@echo "- Removing linked files"
-	@rm -f $(LINK)
-
 link: $(LINK)
 
 run: $(RUN)
 	@echo $^ | xargs -n 1 $(SHELL)
+
+delete:
+	@echo "- Removing linked files"
+	@rm -f $(LINK)

--- a/gh/config.yml
+++ b/gh/config.yml
@@ -1,0 +1,17 @@
+# The current version of the config schema
+version: 1
+# What protocol to use when performing git operations. Supported values: ssh, https
+git_protocol: https
+# What editor gh should run when creating issues, pull requests, etc. If blank, will refer to environment.
+editor:
+# When to interactively prompt. This is a global config that cannot be overridden by hostname. Supported values: enabled, disabled
+prompt: enabled
+# A pager program to send command output to, e.g. "less". If blank, will refer to environment. Set the value to "cat" to disable the pager.
+pager:
+# Aliases allow you to create nicknames for gh commands
+aliases:
+    co: pr checkout
+# The path to a unix socket through which send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.
+http_unix_socket:
+# What web browser gh should use when opening URLs. If blank, will refer to environment.
+browser:

--- a/gh/gh.install
+++ b/gh/gh.install
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo "- Linking ~/.config/gh/config.yml"
+
+mkdir -p ~/.config/gh
+
+ln -sF ~/.dotfiles/gh/config.yml ~/.config/gh/config.yml

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -1,0 +1,2 @@
+[tools]
+node = "lts"

--- a/mise/mise.install
+++ b/mise/mise.install
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+echo "- Linking ~/.config/mise"
+
+mkdir -p ~/.config
+rm -rf ~/.config/mise
+
+ln -sF ~/.dotfiles/mise ~/.config/mise

--- a/starship/starship.toml
+++ b/starship/starship.toml
@@ -1,6 +1,6 @@
 add_newline = false
 format = """
-$character$directory$git_branch$git_status ${custom.separator}"""
+$character$directory$git_branch$git_status """
 
 [character]
 error_symbol = "[􀇿 ](bold)"
@@ -29,10 +29,3 @@ untracked = "􀈷 "
 
 [swift]
 disabled = true
-
-[custom.separator]
-command = "prompt_separator"
-description = "A custom separator, indicating the style of the repo"
-format = "[($output  )]($style)"
-style = "bold"
-when = true


### PR DESCRIPTION
## Summary
- Add `gh` config (`config.yml` + install script) with `co` alias for `pr checkout`
- Add `mise` config (`config.toml` + install script) with Node LTS default
- Remove dead `custom.separator` section from `starship.toml` (`prompt_separator` function doesn't exist)
- Clean up `Makefile` with `.PHONY` targets