### PR TITLE
Add brew update before bundle install

### DIFF
--- a/brew/bundle.install
+++ b/brew/bundle.install
@@ -1,6 +1,8 @@
 #!/bin/zsh
 if command -v brew &>/dev/null
 then
+  echo "- Updating Homebrew"
+  brew update
   echo "- Installing packages from brew"
   brew bundle --no-upgrade --file=~/.dotfiles/brew/Brewfile
 else


### PR DESCRIPTION
## Summary
- Runs `brew update` before `brew bundle` to ensure taps and formulas are available on fresh machines
- Fixes "failed to fetch" errors when setting up a new computer

## Test plan
- [ ] Run `make run` on a fresh machine and verify no fetch failures