### PR TITLE
Remove separate qmk tap

### DIFF
--- a/brew/Brewfile
+++ b/brew/Brewfile
@@ -5,7 +5,6 @@ cask_args appdir: "/Applications"
 tap "tw93/tap"
 tap "heroku/brew"
 tap "pointfreeco/tap"
-tap "qmk/qmk"
 
 # Install packages
 brew "coreutils"


### PR DESCRIPTION
## Summary
- Remove explicit `tap "qmk/qmk"` since `brew "qmk/qmk/qmk"` auto-taps

## Test plan
- [ ] Run `brew bundle` on fresh machine