### PR TITLE
Set fish as default shell during install

### DIFF
--- a/fish/fish.install
+++ b/fish/fish.install
@@ -6,3 +6,16 @@ mkdir -p ~/.config
 rm -rf ~/.config/fish
 
 ln -sF ~/.dotfiles/fish/config/ ~/.config/fish
+
+# Set fish as default shell
+FISH_PATH=/opt/homebrew/bin/fish
+if [ -x "$FISH_PATH" ]; then
+  if ! grep -q "$FISH_PATH" /etc/shells; then
+    echo "- Adding fish to /etc/shells (requires sudo)"
+    echo "$FISH_PATH" | sudo tee -a /etc/shells >/dev/null
+  fi
+  if [ "$SHELL" != "$FISH_PATH" ]; then
+    echo "- Setting fish as default shell"
+    chsh -s "$FISH_PATH"
+  fi
+fi


### PR DESCRIPTION
## Summary
- Add fish to `/etc/shells` and run `chsh` in `fish.install`
- Skips if already configured
- Requires sudo on fresh machines

## Test plan
- [ ] Run on fresh machine, verify fish is default shell in new terminal