### PR TITLE
Guard 1Password plugins source in fish config

### DIFF
--- a/fish/config/config.fish
+++ b/fish/config/config.fish
@@ -5,7 +5,7 @@ source ~/.config/fish/abbreviations.fish
 source ~/.config/fish/aliases.fish
 
 # 1Password
-source ~/.config/op/plugins.sh
+test -f ~/.config/op/plugins.sh; and source ~/.config/op/plugins.sh
 
 # Locale
 set -x LANGUAGE "en_US.UTF-8"


### PR DESCRIPTION
## Summary
- Skip sourcing `~/.config/op/plugins.sh` if file doesn't exist
- Prevents error on fresh machines before `op plugin init` is run

## Test plan
- [ ] Open fish without `~/.config/op/plugins.sh` — no error
- [ ] Run `op plugin init`, reopen fish — plugins load